### PR TITLE
Clarify optional CNAME in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ npm run build
 ```
 
 ## Deploy to GitHub Pages
-
-- Ensure the `CNAME` file in `public/` is set to your custom domain (if using one).
+- Custom domains can use a `CNAME` file in `public/`; this file is optional and not included by default.
 - Push the `dist/` folder to the `gh-pages` branch or configure your repository for GitHub Pages deployment.
 
 ## License


### PR DESCRIPTION
## Summary
- rephrase the deployment instructions about `CNAME`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684bb117d9848329b9359ae5cda82b7f